### PR TITLE
Included in this pull request the latest local commit with the Seaborn formatted line chart 

### DIFF
--- a/data_wrangling_scripts/10 Import excel file creating standard date variable.ipynb
+++ b/data_wrangling_scripts/10 Import excel file creating standard date variable.ipynb
@@ -4311,7 +4311,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 72,
+   "execution_count": null,
    "id": "8c074fcf",
    "metadata": {},
    "outputs": [
@@ -4327,6 +4327,7 @@
     }
    ],
    "source": [
+    "# Final chart Total population in Spain 1972-2025\n",
     "sns.set(rc={'figure.figsize':(15,7)})\n",
     "sns.lineplot(data=population_total_chart_data, x='date_fmt', y='Total_population', marker = '*', color = 'tomato').set_title(\"Total population in Spain.1972-2025 period. Source:INE\") \n",
     "plt.ticklabel_format(style='plain', axis='y') # This will supress scientific notation\n",


### PR DESCRIPTION
- This PR includes the latest section of code from script "10 Import excel file creating standard data variable.ipynb" 
`sns.set(rc={'figure.figsize':(15,7)})
sns.lineplot(data=population_total_chart_data, x='date_fmt', y='Total_population', marker = '*', color = 'tomato').set_title("Total population in Spain.1972-2025 period. Source:INE") 
plt.ticklabel_format(style='plain', axis='y') # This will supress scientific notation
plt.savefig('Seaborn_gallery/Seaborn_plots/Spain_total_population_1972_2025_period_line_chart.png', bbox_inches='tight') ## This saves the output plot successfully in the project folder
plt.show()
`
<img width="1240" height="776" alt="image" src="https://github.com/user-attachments/assets/9834b2b8-4ed0-4145-8abc-6dd2857d19fe" />

- Also this pull request includes a section on how to create a date variable from three independent string columns using pd.to_datetime() method: 

`new_date_var['date'] = new_date_var['day'] + "/" + new_date_var['month_num']+ "/" + new_date_var['year']
new_date_var.head()`

`new_date_var['date_fmt'] = pd.to_datetime(new_date_var['date'],format = '%d/%m/%Y')
new_date_var.head()`

- This formatted Date column allowed me to create the final Seaborn with the correct date formats in the X axis.